### PR TITLE
Enhance Token Refresh Logic

### DIFF
--- a/src/Repository/ExactRepository.php
+++ b/src/Repository/ExactRepository.php
@@ -18,4 +18,13 @@ final class ExactRepository extends EntityRepository
 
         return $qb->getQuery()->getOneOrNullResult();
     }
+
+    public function findLastFew($count)
+    {
+        $qb = $this->createQueryBuilder('e');
+        $qb->setMaxResults($count);
+        $qb->orderBy('e.id', 'DESC');
+
+        return $qb->getQuery()->getResult();
+    }
 }


### PR DESCRIPTION
**Key Changes**

1. Loop Over Multiple Records:
2. New Repository Method - findLastFew($count)


**Why This Change?**
The previous implementation had a fallback mechanism but was limited to only one refresh_token attempts. Given the potential for multiple tokens to be available, this change increases resilience by trying more options before considering the operation a failure.